### PR TITLE
[Feature #158628183] Retrieve a single ride offer.

### DIFF
--- a/application/views/ride_views.py
+++ b/application/views/ride_views.py
@@ -133,6 +133,32 @@ class AllRides(Resource):
             raise e
 
 
+class SingleRide(Resource):
+
+    @api.doc('Get Available rides',
+             params={'ride_id': 'Id for a single ride offer'},
+             responses={200: 'OK', 404: 'NOT FOUND'})
+    @jwt_required
+    def get(self, ride_id):
+        """Retrieves all available rides"""
+        try:
+            query = "SELECT * from rides where rides.ride_id = '{}'"\
+                . format(ride_id)
+            cursor.execute(query)
+            rows = cursor.fetchall()
+
+            if len(rows) > 0:
+                return jsonify([
+                    {'id': row[0], 'start point': row[2],
+                     'destination': row[3], 'start_time': row[4],
+                     'route': row[5],
+                     'available space': row[6]}
+                    for row in rows])
+            return {'message': 'Offer not found'}, 404
+        except Exception as e:
+            raise e
+
+
 class JoinRide(Resource):
 
     @api.doc('Request to join a ride offer',
@@ -178,4 +204,5 @@ class JoinRide(Resource):
 
 api.add_resource(Rides, '/users/rides')
 api.add_resource(AllRides, '/rides')
+api.add_resource(SingleRide, '/rides/<string:ride_id>')
 api.add_resource(JoinRide, '/rides/<ride_id>/requests')

--- a/tests/testRides.py
+++ b/tests/testRides.py
@@ -115,7 +115,7 @@ class RidesOfferTests(unittest.TestCase):
                                  data=json.dumps(self.ride_with_wrong_date),
                                  content_type='application/json',
                                  headers=self.headers)
-        
+
         response_data = json.loads(response.get_data().decode('utf-8'))
         self.assertEqual(response_data['message'],
                          "use correct format for date and time.")
@@ -166,6 +166,20 @@ class RidesOfferTests(unittest.TestCase):
         response_data = json.loads(response.get_data().decode('utf-8'))
         self.assertTrue(response_data[0] is not None)
 
+    def test_get_a_rides(self):
+        """test user can get available ride offers."""
+        # Create a ride offer to be sure there is an offer
+        response = self.app.post('/api/v1/users/rides',
+                                 data=json.dumps(self.ride),
+                                 content_type='application/json',
+                                 headers=self.headers)
+        response = self.app.get('/api/v1/rides/1',
+                                content_type='application/json',
+                                headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.get_data().decode('utf-8'))
+        self.assertTrue(response_data[0] is not None)
+
     def test_user_can_request_a_ride(self):
         """test user can join a ride."""
         # create a ride to be sure a ride exists.
@@ -180,6 +194,25 @@ class RidesOfferTests(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response_data['message'],
                          "Your request has been send.")
+
+    def test_user_cannot_request_same_ride_twice(self):
+        """test user cannot request to join a ride more than once."""
+        # create a ride to be sure a ride exists.
+        response = self.app.post('/api/v1/users/rides',
+                                 data=json.dumps(self.ride),
+                                 content_type='application/json',
+                                 headers=self.headers)
+        # Requests same ride more than once
+        self.app.post('/api/v1/rides/1/requests',
+                      content_type='application/json',
+                      headers=self.headers)
+        response = self.app.post('/api/v1/rides/1/requests',
+                                 content_type='application/json',
+                                 headers=self.headers)
+        response_data = json.loads(response.get_data().decode('utf-8'))
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response_data['message'],
+                         "You already requested this ride.")
 
     def test_user_cannot_request_a_non_existing_ride(self):
         """test user cannot request a non existing ride offer."""


### PR DESCRIPTION
#### What does this PR do?
Add endpoint for retrieving all available ride offers

#### Description of Task to be completed?
- Add view function to `GET /rides/<rideId>`
- Implement actual ride retrieval within the view function

#### How should this be manually tested?
using your terminal,
- clone this repo
- `cd ride-my-way`
- set and activate your virtual environment
- `git checkout ft-get-rides-158628183`
- Run `python3 run.py`
- Using Postman, access `GET your-server/api/v1/rides/<rideId>`

**Screenshot**
![ride offer](https://user-images.githubusercontent.com/9263906/42049012-6a614b6c-7b0d-11e8-9411-e17b08010ed9.png)


**Pivotal tracker stories**
[Retrieve single ride #158628183](https://www.pivotaltracker.com/story/show/158628183)